### PR TITLE
Fix sign-compare warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .svn
+*.a
+*.o
+example

--- a/HOTVR.cc
+++ b/HOTVR.cc
@@ -159,7 +159,7 @@ namespace contrib {
 
 	      bool set=false;
 	      std::vector<fastjet::PseudoJet> subjets;
-	      for(int o=0;o<_jets.size();o++){ 
+	      for(uint o=0;o<_jets.size();o++){
 	        if(_jets[o].user_index()==i) {
 	          _jets[_jets.size()-1].set_user_index(i*100);
 	          if(!set) {
@@ -214,7 +214,7 @@ namespace contrib {
 	      if(cs.jets()[i].pt()>=_pt_sub && cs.jets()[j].pt()>=_pt_sub) {//check if the subjet pT is higher than the threshold 	
 	        cs.plugin_record_ij_recombination(i, j, dij, k);
 
-  	      for(int o=0;o<_jets.size();o++){ 	    	   
+  	      for(uint o=0;o<_jets.size();o++){
 	          if(_jets[o].user_index()==j) {
 	            _jets[o].set_user_index(k);
 	            existing_j=true;

--- a/HOTVRinfo.cc
+++ b/HOTVRinfo.cc
@@ -59,7 +59,7 @@ namespace contrib{
   double HOTVRinfo::max_distance() const { //calculates the size of the jet, by finding the constituent with the largest distance. Can be used as an estimate for a jet radius
     std::vector<fastjet::PseudoJet> pfcands = _parent.constituents();
     double oldR=0;
-    for(int j=0;j<pfcands.size();j++){
+    for(uint j=0;j<pfcands.size();j++){
       double R;
       R=_parent.delta_R(pfcands[j]);
 	    if(R>oldR){

--- a/HOTVRinfo.cc
+++ b/HOTVRinfo.cc
@@ -49,7 +49,7 @@ namespace contrib{
 }
 
 
-  double HOTVRinfo::ptfraction(int i) const { //calculate the pTfraction pT_{subjet,i}/pT_{jet}
+  double HOTVRinfo::ptfraction(uint i) const { //calculate the pTfraction pT_{subjet,i}/pT_{jet}
   double ptfraction=0;
   if(_subjets.size()>i)
     ptfraction=_subjets.at(i).perp()/_parent.perp();

--- a/HOTVRinfo.hh
+++ b/HOTVRinfo.hh
@@ -54,7 +54,7 @@ namespace contrib{
     double mmin() const;
 
     // ptfraction of subjet i, given by p_T,i / p_T,fatjet
-    double ptfraction(int i) const;
+    double ptfraction(uint i) const;
        
   private:
     std::vector<fastjet::PseudoJet> _subjets;

--- a/example.cc
+++ b/example.cc
@@ -102,7 +102,7 @@ int main(){
     print_jets(hotvr_jets, clust_seq);
     
     // now access subjets with the info class and print them
-    for(int i=0;i<hotvr_jets.size();i++)
+    for(uint i=0;i<hotvr_jets.size();i++)
       {
         // vector with subjets of fatjet i
         // subjets saved in user_info class HOTVRinfo


### PR DESCRIPTION
Change ints to uints when they are used to access vector elements. Fixes `-Wsign-compare` warnings during compilation. Does not change functionality.

These now arise as we now use `-Wall` during compilation (see UHH2/UHH2#1050)